### PR TITLE
Convert teufel namespace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,11 @@ jobs:
         name: "Checkout code"
         uses: "actions/checkout@v2"
       -
+        name: "Install docker-compose"
+        run: |
+          sudo curl -L "https://github.com/docker/compose/releases/download/2.12.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo chmod +x /usr/local/bin/docker-compose
+      -
         name: "Start container"
         run: docker-compose up -d
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,8 +19,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - '7.4'
-          - '8.0'
+          - '8.1'
 
     steps:
       -

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       -
         name: "Install docker-compose"
         run: |
-          sudo curl -L "https://github.com/docker/compose/releases/download/2.12.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+          sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
           sudo chmod +x /usr/local/bin/docker-compose
       -
         name: "Start container"

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /tests/Workspace
 /tests/App/config/Shared/config_local.php
 /tests/App/data
+/.idea

--- a/README.md
+++ b/README.md
@@ -12,15 +12,15 @@ Installation
 Require the package with composer:
 
 ```
-$ composer require inviqa/spryker-debug
+$ composer require teufelaudio/spryker-debug
 ```
 
-Add the `Inviqa` namespace to the `CORE_NAMESPACES` key in your `config/Shared/config_default.php` file:
+Add the `Teufelaudio` namespace to the `CORE_NAMESPACES` key in your `config/Shared/config_default.php` file:
 
 ```php
 $config[KernelConstants::CORE_NAMESPACES] = [
     // ...
-    'Inviqa',
+    'Teufelaudio',
 ];
 ```
 

--- a/behat.yml
+++ b/behat.yml
@@ -3,18 +3,18 @@ default:
     zed:
 
       autowire: true
-      services: Inviqa\SprykerDebug\Tests\TestContainer
+      services: Teufelaudio\SprykerDebug\Tests\TestContainer
 
       contexts:
-        - Inviqa\SprykerDebug\Tests\Acceptance\Context\DatabaseContext
-        - Inviqa\SprykerDebug\Tests\Acceptance\Context\WorkspaceContext
-        - Inviqa\SprykerDebug\Tests\Acceptance\Context\ConsoleContext
-        - Inviqa\SprykerDebug\Tests\Acceptance\Context\ConfigContext
-        - Inviqa\SprykerDebug\Tests\Acceptance\Context\QueueContext
-        - Inviqa\SprykerDebug\Tests\Acceptance\Context\TwigContext
-        - Inviqa\SprykerDebug\Tests\Acceptance\Context\YvesHttpContext
-        - Inviqa\SprykerDebug\Tests\Acceptance\Context\CacheContext
-        - Inviqa\SprykerDebug\Tests\Acceptance\Context\PropelContext
+        - Teufelaudio\SprykerDebug\Tests\Acceptance\Context\DatabaseContext
+        - Teufelaudio\SprykerDebug\Tests\Acceptance\Context\WorkspaceContext
+        - Teufelaudio\SprykerDebug\Tests\Acceptance\Context\ConsoleContext
+        - Teufelaudio\SprykerDebug\Tests\Acceptance\Context\ConfigContext
+        - Teufelaudio\SprykerDebug\Tests\Acceptance\Context\QueueContext
+        - Teufelaudio\SprykerDebug\Tests\Acceptance\Context\TwigContext
+        - Teufelaudio\SprykerDebug\Tests\Acceptance\Context\YvesHttpContext
+        - Teufelaudio\SprykerDebug\Tests\Acceptance\Context\CacheContext
+        - Teufelaudio\SprykerDebug\Tests\Acceptance\Context\PropelContext
 
   extensions:
     Roave\BehatPsrContainer\PsrContainerExtension:

--- a/ci/bootstrap.php
+++ b/ci/bootstrap.php
@@ -2,6 +2,6 @@
 
 require __DIR__ . '/../vendor/autoload.php';
 
-use Inviqa\SprykerDebug\Tests\TestContainer;
+use Teufelaudio\SprykerDebug\Tests\TestContainer;
 
 $container = (new TestContainer());

--- a/ci/bootstrap.sh
+++ b/ci/bootstrap.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # Delete any migrations etc
-rm -Rf tests/App/src/Orm/
+rm -Rf tests/App/src/Orm/ tests/App/src/Generated
 
 ./tests/App/bin/console transfer:generate
 ./tests/App/bin/console propel:install

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
-    "name": "inviqa/spryker-debug",
-    "description": "Inviqa Spryker Debug Module",
+    "name": "teufelaudio/spryker-debug",
+    "description": "Spryker Debug Module",
     "type": "library",
     "license": "MIT",
     "authors": [
@@ -11,19 +11,19 @@
     ],
     "autoload": {
       "psr-4": {
-        "Inviqa\\": "src/"
+        "Teufelaudio\\": "src/"
       }
     },
     "autoload-dev": {
       "psr-4": {
         "Orm\\": "tests/App/src/Orm/",
         "Pyz\\": "tests/App/src/Pyz/",
-        "Inviqa\\SprykerDebug\\Tests\\": "tests/",
+        "Teufelaudio\\SprykerDebug\\Tests\\": "tests/",
         "Generated\\Shared\\Transfer\\": "tests/App/src/Generated/Shared/Transfer/"
       }
     },
     "require": {
-        "php": "^7.4 | ^8.0",
+        "php": "^8.0",
         "spryker-shop/shop-application": "^1.0",
         "spryker/propel": "^3.0",
         "spryker/console": "^4.0",

--- a/composer.json
+++ b/composer.json
@@ -23,17 +23,17 @@
       }
     },
     "require": {
-        "php": "^8.0",
+        "php": "^8.1",
         "spryker-shop/shop-application": "^1.0",
         "spryker/propel": "^3.0",
         "spryker/console": "^4.0",
         "guzzlehttp/guzzle": "^6.0 || ^7.0",
         "spryker/rabbit-mq": "^2.0",
-        "symfony/var-dumper": "^4.0|^5.0|^6.0",
+        "symfony/var-dumper": "^6.0",
         "spryker/zed-request": "^3.8"
     },
     "require-dev": {
-        "propel/propel": "2.0.0-alpha12",
+        "propel/propel": "2.0.0-beta3",
         "behat/behat": "^3.5",
         "spryker-sdk/phpstan-spryker": "^0.4",
         "roave/behat-psr11extension": "^2.1",
@@ -44,7 +44,8 @@
         "spryker/router": "^1.3",
         "spryker/http": "^1.0",
         "spryker/event-dispatcher": "^1.0",
-        "phpstan/phpdoc-parser": "^1.6"
+        "phpstan/phpdoc-parser": "^1.6",
+        "psr/log": "^2.0"
     },
     "extra": {
         "branch-alias": {

--- a/doc/config_dump.md
+++ b/doc/config_dump.md
@@ -20,7 +20,7 @@ Add the `DebugConfigConsole` to your `ConsoleDependencyProvider`:
 namespace Pyz\Zed\Console;
 
 // ...
-use Inviqa\Zed\SprykerDebug\Communication\Console\DebugConfigConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\DebugConfigConsole;
 
 class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
 {

--- a/doc/database_shell.md
+++ b/doc/database_shell.md
@@ -15,7 +15,7 @@ Add the `DatabaseShellConsole` to your `ConsoleDependencyProvider`:
 namespace Pyz\Zed\Console;
 
 // ...
-use Inviqa\Zed\SprykerDebug\Communication\Console\DatabaseShellConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\DatabaseShellConsole;
 
 class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
 {

--- a/doc/guzzle_profiler.md
+++ b/doc/guzzle_profiler.md
@@ -15,7 +15,7 @@ Add the `GuzzleProfilerApplicationPlugin` to your
 namespace Pyz\Zed\Console;
 
 // ...
-use Inviqa\Shared\SprykerDebug\Plugin\Application\GuzzleProfilerApplicationPlugin;
+use Teufelaudio\Shared\SprykerDebug\Plugin\Application\GuzzleProfilerApplicationPlugin;
 
 class ShopApplicationDependencyProvider extends SprykerShopApplicationDependencyProvider
 {

--- a/doc/propel_entity.md
+++ b/doc/propel_entity.md
@@ -14,7 +14,7 @@ Add the `PropelDumpEntityConsole` to your `ConsoleDependencyProvider`:
 namespace Pyz\Zed\Console;
 
 // ...
-use Inviqa\Zed\SprykerDebug\Communication\Console\PropelDumpEntityConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\PropelDumpEntityConsole;
 
 class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
 {

--- a/doc/propel_metadata.md
+++ b/doc/propel_metadata.md
@@ -14,7 +14,7 @@ Add the `PropelDumpMetadataConsole` to your `ConsoleDependencyProvider`:
 namespace Pyz\Zed\Console;
 
 // ...
-use Inviqa\Zed\SprykerDebug\Communication\Console\PropelDumpMetadataConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\PropelDumpMetadataConsole;
 
 class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
 {

--- a/doc/queue_overview.md
+++ b/doc/queue_overview.md
@@ -17,7 +17,7 @@ Add the `DebugQueuesConsole` to your `ConsoleDependencyProvider`:
 namespace Pyz\Zed\Console;
 
 // ...
-use Inviqa\Zed\SprykerDebug\Communication\Console\DebugQueuesConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\DebugQueuesConsole;
 
 class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
 {

--- a/doc/queue_peek.md
+++ b/doc/queue_peek.md
@@ -14,7 +14,7 @@ Add the `DebugQueuesPeekConsole` to your `ConsoleDependencyProvider`:
 namespace Pyz\Zed\Console;
 
 // ...
-use Inviqa\Zed\SprykerDebug\Communication\Console\DebugQueuesConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\DebugQueuesConsole;
 
 class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
 {

--- a/doc/redis_shell.md
+++ b/doc/redis_shell.md
@@ -15,7 +15,7 @@ Add the `RedisShellConsole` to your `ConsoleDependencyProvider`:
 namespace Pyz\Zed\Console;
 
 // ...
-use Inviqa\Zed\SprykerDebug\Communication\Console\RedisShellConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\RedisShellConsole;
 
 class ConsoleDependencyProvider extends SprykerConsoleDependencyProvider
 {

--- a/doc/twig_var_dumper.md
+++ b/doc/twig_var_dumper.md
@@ -18,7 +18,7 @@ Add the `TwigVarDumpServiceProvider` to your `ShopApplicationDependencyProvider`
 namespace Pyz\Yves\ShopApplication;
 
 // ...
-use Inviqa\Shared\SprykerDebug\Plugin\Provider\TwigVarDumpServiceProvider;
+use Teufelaudio\Shared\SprykerDebug\Plugin\Provider\TwigVarDumpServiceProvider;
 
 class ShopApplicationDependencyProvider extends SprykerShopApplicationDependencyProvider
 {
@@ -40,7 +40,7 @@ Add the `TwigVarDumpServiceProvider` to your `ApplicationDependencyProvider`:
 <?php
 
 // ...
-use Inviqa\Shared\SprykerDebug\Plugin\Provider\TwigVarDumpServiceProvider;
+use Teufelaudio\Shared\SprykerDebug\Plugin\Provider\TwigVarDumpServiceProvider;
 
 class ApplicationDependencyProvider extends SprykerApplicationDependencyProvider
 {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,10 +1,11 @@
 parameters:
     level: 6
-    checkMissingIterableValueType: false
-    checkGenericClassInNonGenericObjectType: false
     excludePaths:
         - %rootDir%/../../../src/Generated/*
         - %rootDir%/../../../src/Orm/*
         - %rootDir%/../../../src/Mcrm/SoapType*
     bootstrapFiles:
         - %rootDir%/../../../ci/bootstrap.php
+    ignoreErrors:
+        - identifier: missingType.iterableValue
+        - identifier: missingType.generics

--- a/src/Shared/SprykerDebug/Plugin/Application/GuzzleProfilerApplicationPlugin.php
+++ b/src/Shared/SprykerDebug/Plugin/Application/GuzzleProfilerApplicationPlugin.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Inviqa\Shared\SprykerDebug\Plugin\Application;
+namespace Teufelaudio\Shared\SprykerDebug\Plugin\Application;
 
-use Inviqa\Shared\SprykerDebug\Plugin\Guzzle\GuzzleStopwatchProfilerMiddleware;
 use Spryker\Service\Container\ContainerInterface;
 use Spryker\Shared\ApplicationExtension\Dependency\Plugin\ApplicationPluginInterface;
 use Spryker\Shared\ZedRequest\Client\HandlerStack\HandlerStackContainer;
+use Teufelaudio\Shared\SprykerDebug\Plugin\Guzzle\GuzzleStopwatchProfilerMiddleware;
 
 class GuzzleProfilerApplicationPlugin implements ApplicationPluginInterface
 {

--- a/src/Shared/SprykerDebug/Plugin/Application/TwigVarDumpApplicationPlugin.php
+++ b/src/Shared/SprykerDebug/Plugin/Application/TwigVarDumpApplicationPlugin.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Shared\SprykerDebug\Plugin\Application;
+namespace Teufelaudio\Shared\SprykerDebug\Plugin\Application;
 
 use Spryker\Service\Container\ContainerInterface;
 use Spryker\Shared\ApplicationExtension\Dependency\Plugin\ApplicationPluginInterface;

--- a/src/Shared/SprykerDebug/Plugin/Guzzle/GuzzleStopwatchProfilerMiddleware.php
+++ b/src/Shared/SprykerDebug/Plugin/Guzzle/GuzzleStopwatchProfilerMiddleware.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Shared\SprykerDebug\Plugin\Guzzle;
+namespace Teufelaudio\Shared\SprykerDebug\Plugin\Guzzle;
 
 use Closure;
 use Psr\Http\Message\RequestInterface;

--- a/src/Zed/SprykerDebug/Communication/Console/AbstractShellConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/AbstractShellConsole.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Console;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Console;
 
 use RuntimeException;
 use Spryker\Zed\Kernel\Communication\Console\Console;

--- a/src/Zed/SprykerDebug/Communication/Console/DatabaseShellConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DatabaseShellConsole.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Console;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Console;
 
-use Inviqa\Zed\SprykerDebug\Communication\Model\Cast;
 use Spryker\Shared\Config\Config;
 use Spryker\Shared\Propel\PropelConstants;
 use Symfony\Component\Console\Input\InputInterface;
@@ -10,6 +9,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Cast;
 
 class DatabaseShellConsole extends AbstractShellConsole
 {

--- a/src/Zed/SprykerDebug/Communication/Console/DebugConfigConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DebugConfigConsole.php
@@ -1,9 +1,7 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Console;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Console;
 
-use Inviqa\Zed\SprykerDebug\Communication\Model\Cast;
-use Inviqa\Zed\SprykerDebug\Communication\Model\Config\ConfigTypeExtractingConfig;
 use ReflectionClass;
 use Spryker\Shared\Config\Config;
 use Spryker\Zed\Kernel\Communication\Console\Console;
@@ -12,6 +10,8 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Cast;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Config\ConfigTypeExtractingConfig;
 
 class DebugConfigConsole extends Console
 {

--- a/src/Zed/SprykerDebug/Communication/Console/DebugQueuesConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DebugQueuesConsole.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Console;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Console;
 
-use Inviqa\Zed\SprykerDebug\Communication\Model\Cast;
 use Spryker\Zed\Kernel\Communication\Console\Console;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Cast;
 
 /**
- * @method \Inviqa\Zed\SprykerDebug\Communication\SprykerDebugCommunicationFactory getFactory()
+ * @method \Teufelaudio\Zed\SprykerDebug\Communication\SprykerDebugCommunicationFactory getFactory()
  */
 class DebugQueuesConsole extends Console
 {

--- a/src/Zed/SprykerDebug/Communication/Console/DebugQueuesPeekConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/DebugQueuesPeekConsole.php
@@ -1,17 +1,17 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Console;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Console;
 
-use Inviqa\Zed\SprykerDebug\Communication\Model\Cast;
 use RuntimeException;
 use Spryker\Zed\Kernel\Communication\Console\Console;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Cast;
 
 /**
- * @method \Inviqa\Zed\SprykerDebug\Communication\SprykerDebugCommunicationFactory getFactory()
+ * @method \Teufelaudio\Zed\SprykerDebug\Communication\SprykerDebugCommunicationFactory getFactory()
  */
 class DebugQueuesPeekConsole extends Console
 {

--- a/src/Zed/SprykerDebug/Communication/Console/PropelDumpEntityConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/PropelDumpEntityConsole.php
@@ -1,10 +1,7 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Console;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Console;
 
-use Inviqa\Zed\SprykerDebug\Communication\Model\Cast;
-use Inviqa\Zed\SprykerDebug\Communication\Model\Propel\CriteriaParser;
-use Inviqa\Zed\SprykerDebug\Communication\Model\Propel\FieldParser;
 use Propel\Runtime\ActiveQuery\ModelCriteria;
 use Propel\Runtime\ActiveRecord\ActiveRecordInterface;
 use Propel\Runtime\Collection\Collection;
@@ -17,9 +14,12 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Cast;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel\CriteriaParser;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel\FieldParser;
 
 /**
- * @method \Inviqa\Zed\SprykerDebug\Communication\SprykerDebugCommunicationFactory getFactory()
+ * @method \Teufelaudio\Zed\SprykerDebug\Communication\SprykerDebugCommunicationFactory getFactory()
  */
 class PropelDumpEntityConsole extends Console
 {
@@ -34,12 +34,12 @@ class PropelDumpEntityConsole extends Console
     private const OPT_FIELDS = 'fields';
 
     /**
-     * @var \Inviqa\Zed\SprykerDebug\Communication\Model\Propel\CriteriaParser
+     * @var \Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel\CriteriaParser
      */
     private $criteriaParser;
 
     /**
-     * @var \Inviqa\Zed\SprykerDebug\Communication\Model\Propel\FieldParser
+     * @var \Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel\FieldParser
      */
     private $fieldParser;
 

--- a/src/Zed/SprykerDebug/Communication/Console/PropelDumpMetadataConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/PropelDumpMetadataConsole.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Console;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Console;
 
 use Propel\Runtime\Map\ColumnMap;
 use Propel\Runtime\Map\RelationMap;
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * @method \Inviqa\Zed\SprykerDebug\Communication\SprykerDebugCommunicationFactory getFactory()
+ * @method \Teufelaudio\Zed\SprykerDebug\Communication\SprykerDebugCommunicationFactory getFactory()
  */
 class PropelDumpMetadataConsole extends Console
 {

--- a/src/Zed/SprykerDebug/Communication/Console/RedisShellConsole.php
+++ b/src/Zed/SprykerDebug/Communication/Console/RedisShellConsole.php
@@ -1,8 +1,7 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Console;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Console;
 
-use Inviqa\Zed\SprykerDebug\Communication\Model\Cast;
 use Spryker\Shared\Config\Config;
 use Spryker\Shared\Storage\StorageConstants;
 use Symfony\Component\Console\Input\InputInterface;
@@ -10,6 +9,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Cast;
 
 class RedisShellConsole extends AbstractShellConsole
 {

--- a/src/Zed/SprykerDebug/Communication/Model/Cast.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Cast.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model;
 
 class Cast
 {

--- a/src/Zed/SprykerDebug/Communication/Model/Config/ConfigTypeExtractingConfig.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Config/ConfigTypeExtractingConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Config;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Config;
 
 use ArrayObject;
 use Spryker\Shared\Config\Config;

--- a/src/Zed/SprykerDebug/Communication/Model/Config/KeyTrackingArrayObject.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Config/KeyTrackingArrayObject.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Config;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Config;
 
 use ArrayObject;
 

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/CriteriaParser.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/CriteriaParser.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Propel;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel;
 
 final class CriteriaParser
 {

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/FieldParser.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/FieldParser.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Propel;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel;
 
 final class FieldParser
 {

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/TableNameFinder.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/TableNameFinder.php
@@ -1,18 +1,18 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Propel;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel;
 
 use DOMDocument;
 use DOMXPath;
-use Inviqa\Zed\SprykerDebug\Model\Propel\PropelConfig;
 use Propel\Generator\Model\PhpNameGenerator;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
+use Teufelaudio\Zed\SprykerDebug\Model\Propel\PropelConfig;
 
 class TableNameFinder
 {
     /**
-     * @var \Inviqa\Zed\SprykerDebug\Model\Propel\PropelConfig
+     * @var \Teufelaudio\Zed\SprykerDebug\Model\Propel\PropelConfig
      */
     private $config;
 

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/Tables.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/Tables.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Propel;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel;
 
 use ArrayIterator;
 use Iterator;

--- a/src/Zed/SprykerDebug/Communication/Model/Propel/TablesFactory.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Propel/TablesFactory.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Propel;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel;
 
 use Propel\Runtime\Map\DatabaseMap;
 use Propel\Runtime\Map\Exception\TableNotFoundException;
@@ -13,7 +13,7 @@ class TablesFactory
     private $map;
 
     /**
-     * @var \Inviqa\Zed\SprykerDebug\Communication\Model\Propel\TableNameFinder
+     * @var \Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel\TableNameFinder
      */
     private $finder;
 

--- a/src/Zed/SprykerDebug/Communication/Model/Rabbit/Message.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Rabbit/Message.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Rabbit;
 
 class Message
 {

--- a/src/Zed/SprykerDebug/Communication/Model/Rabbit/Messages.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Rabbit/Messages.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Rabbit;
 
 use ArrayIterator;
 use Iterator;

--- a/src/Zed/SprykerDebug/Communication/Model/Rabbit/Queue.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Rabbit/Queue.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Rabbit;
 
 class Queue
 {

--- a/src/Zed/SprykerDebug/Communication/Model/Rabbit/Queues.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Rabbit/Queues.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Rabbit;
 
 use ArrayIterator;
 use Countable;

--- a/src/Zed/SprykerDebug/Communication/Model/Rabbit/RabbitClient.php
+++ b/src/Zed/SprykerDebug/Communication/Model/Rabbit/RabbitClient.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit;
+namespace Teufelaudio\Zed\SprykerDebug\Communication\Model\Rabbit;
 
 use GuzzleHttp\Client;
 use RuntimeException;
@@ -17,9 +17,6 @@ final class RabbitClient
         $this->client = $client;
     }
 
-    /**
-     * @return \Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit\Queues<\Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit\Queue>
-     */
     public function queues(): Queues
     {
         return new Queues(...array_map(function (array $data) {

--- a/src/Zed/SprykerDebug/Communication/SprykerDebugCommunicationFactory.php
+++ b/src/Zed/SprykerDebug/Communication/SprykerDebugCommunicationFactory.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Communication;
+namespace Teufelaudio\Zed\SprykerDebug\Communication;
 
 use GuzzleHttp\Client;
-use Inviqa\Zed\SprykerDebug\Communication\Model\Propel\TableNameFinder;
-use Inviqa\Zed\SprykerDebug\Communication\Model\Propel\TablesFactory;
-use Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit\RabbitClient;
-use Inviqa\Zed\SprykerDebug\Model\Propel\PropelConfig;
 use Propel\Runtime\Propel;
 use Spryker\Shared\Config\Config;
 use Spryker\Shared\RabbitMq\RabbitMqEnv;
 use Spryker\Zed\Kernel\Communication\AbstractCommunicationFactory;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel\TableNameFinder;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel\TablesFactory;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Rabbit\RabbitClient;
+use Teufelaudio\Zed\SprykerDebug\Model\Propel\PropelConfig;
 
 /**
- * @method \Inviqa\Zed\SprykerDebug\SprykerDebugConfig getConfig()
+ * @method \Teufelaudio\Zed\SprykerDebug\SprykerDebugConfig getConfig()
  */
 class SprykerDebugCommunicationFactory extends AbstractCommunicationFactory
 {

--- a/src/Zed/SprykerDebug/Model/Propel/PropelConfig.php
+++ b/src/Zed/SprykerDebug/Model/Propel/PropelConfig.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\SprykerDebug\Model\Propel;
+namespace Teufelaudio\Zed\SprykerDebug\Model\Propel;
 
 class PropelConfig
 {

--- a/src/Zed/Test/Communication/Controller/GatewayController.php
+++ b/src/Zed/Test/Communication/Controller/GatewayController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\Zed\Test\Communication\Controller;
+namespace Teufelaudio\Zed\Test\Communication\Controller;
 
 use Generated\Shared\Transfer\TestTransfer;
 use Spryker\Shared\ZedRequest\Client\ResponseInterface;

--- a/tests/Acceptance/Context/CacheContext.php
+++ b/tests/Acceptance/Context/CacheContext.php
@@ -13,6 +13,6 @@ class CacheContext implements Context
     public function clearCache()
     {
         $filesystem = new Filesystem();
-        $filesystem->remove(__DIR__ . '/../../App/data/cache');
+        $filesystem->remove(__DIR__ . '/../../App/data/cache/codeBucket');
     }
 }

--- a/tests/Acceptance/Context/CacheContext.php
+++ b/tests/Acceptance/Context/CacheContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Acceptance\Context;
+namespace Teufelaudio\SprykerDebug\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Symfony\Component\Filesystem\Filesystem;

--- a/tests/Acceptance/Context/ConfigContext.php
+++ b/tests/Acceptance/Context/ConfigContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Acceptance\Context;
+namespace Teufelaudio\SprykerDebug\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/Acceptance/Context/ConsoleContext.php
+++ b/tests/Acceptance/Context/ConsoleContext.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Acceptance\Context;
+namespace Teufelaudio\SprykerDebug\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Tester\Exception\PendingException;
 use Behat\Gherkin\Node\PyStringNode;
-use Inviqa\SprykerDebug\Tests\Support\Workspace\Workspace;
+use Teufelaudio\SprykerDebug\Tests\Support\Workspace\Workspace;
 use PHPUnit\Framework\Assert;
 use Symfony\Component\Process\Process;
 

--- a/tests/Acceptance/Context/DatabaseContext.php
+++ b/tests/Acceptance/Context/DatabaseContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Acceptance\Context;
+namespace Teufelaudio\SprykerDebug\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\ScenarioScope;

--- a/tests/Acceptance/Context/PropelContext.php
+++ b/tests/Acceptance/Context/PropelContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Acceptance\Context;
+namespace Teufelaudio\SprykerDebug\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Orm\Zed\SprykerDebug\Persistence\PyzRelatedEntityQuery;

--- a/tests/Acceptance/Context/PropelContext.php
+++ b/tests/Acceptance/Context/PropelContext.php
@@ -8,7 +8,6 @@ use Orm\Zed\SprykerDebug\Persistence\PyzTestEntityQuery;
 
 class PropelContext implements Context
 {
-
     /**
      * @Given a test entity exists with name :name
      */

--- a/tests/Acceptance/Context/QueueContext.php
+++ b/tests/Acceptance/Context/QueueContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Acceptance\Context;
+namespace Teufelaudio\SprykerDebug\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;

--- a/tests/Acceptance/Context/TwigContext.php
+++ b/tests/Acceptance/Context/TwigContext.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Acceptance\Context;
+namespace Teufelaudio\SprykerDebug\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
-use Inviqa\SprykerDebug\Tests\Support\Workspace\Workspace;
+use Teufelaudio\SprykerDebug\Tests\Support\Workspace\Workspace;
 use PHPUnit\Framework\Assert;
 use Twig\Environment;
 

--- a/tests/Acceptance/Context/WorkspaceContext.php
+++ b/tests/Acceptance/Context/WorkspaceContext.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Acceptance\Context;
+namespace Teufelaudio\SprykerDebug\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;
-use Inviqa\SprykerDebug\Tests\Support\Workspace\Workspace;
+use Teufelaudio\SprykerDebug\Tests\Support\Workspace\Workspace;
 
 class WorkspaceContext implements Context
 {

--- a/tests/Acceptance/Context/YvesHttpContext.php
+++ b/tests/Acceptance/Context/YvesHttpContext.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Acceptance\Context;
+namespace Teufelaudio\SprykerDebug\Tests\Acceptance\Context;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\PyStringNode;

--- a/tests/App/bin/console
+++ b/tests/App/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-use Inviqa\SprykerDebug\Tests\TestContainer;
+use Teufelaudio\SprykerDebug\Tests\TestContainer;
 use Spryker\Zed\Console\Communication\Bootstrap\ConsoleBootstrap;
 use Symfony\Component\Debug\Debug;
 

--- a/tests/App/config/Shared/config_default.php
+++ b/tests/App/config/Shared/config_default.php
@@ -10,7 +10,7 @@ $config[KernelConstants::PROJECT_NAMESPACES] = [
     'Pyz',
 ];
 $config[KernelConstants::CORE_NAMESPACES] = [
-    'Inviqa',
+    'Teufelaudio',
     'SprykerShop',
     'SprykerMiddleware',
     'SprykerEco',

--- a/tests/App/src/Pyz/Zed/Application/ApplicationDependencyProvider.php
+++ b/tests/App/src/Pyz/Zed/Application/ApplicationDependencyProvider.php
@@ -2,7 +2,7 @@
 
 namespace Pyz\Zed\Application;
 
-use Inviqa\Shared\SprykerDebug\Plugin\Application\TwigVarDumpApplicationPlugin;
+use Teufelaudio\Shared\SprykerDebug\Plugin\Application\TwigVarDumpApplicationPlugin;
 use Spryker\Zed\Application\ApplicationDependencyProvider as SprykerApplicationDependencyProvider;
 use Spryker\Zed\EventDispatcher\Communication\Plugin\Application\EventDispatcherApplicationPlugin;
 use Spryker\Zed\Http\Communication\Plugin\Application\HttpApplicationPlugin;

--- a/tests/App/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
+++ b/tests/App/src/Pyz/Zed/Console/ConsoleDependencyProvider.php
@@ -2,14 +2,14 @@
 
 namespace Pyz\Zed\Console;
 
-use Inviqa\Zed\SprykerDebug\Communication\Console\DebugConfigConsole;
-use Inviqa\Zed\SprykerDebug\Communication\Console\DatabaseShellConsole;
-use Inviqa\Zed\SprykerDebug\Communication\Console\DebugQueuesConsole;
-use Inviqa\Zed\SprykerDebug\Communication\Console\DebugQueuesPeekConsole;
-use Inviqa\Zed\SprykerDebug\Communication\Console\PropelDumpEntityConsole;
-use Inviqa\Zed\SprykerDebug\Communication\Console\PropelDumpMetadataConsole;
-use Inviqa\Zed\SprykerDebug\Communication\Console\RedisShellConsole;
-use Inviqa\Zed\SprykerDebug\Communication\Console\DebugRoutesConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\DebugConfigConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\DatabaseShellConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\DebugQueuesConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\DebugQueuesPeekConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\PropelDumpEntityConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\PropelDumpMetadataConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\RedisShellConsole;
+use Teufelaudio\Zed\SprykerDebug\Communication\Console\DebugRoutesConsole;
 use Spryker\Zed\Console\ConsoleDependencyProvider as SprykerConsoleDependencyProvider;
 use Spryker\Zed\Kernel\Container;
 use Spryker\Zed\Propel\Communication\Console\BuildModelConsole;

--- a/tests/Support/ApplicationBuilder.php
+++ b/tests/Support/ApplicationBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Support;
+namespace Teufelaudio\SprykerDebug\Tests\Support;
 
 use RuntimeException;
 use Spryker\Service\Container\ContainerInterface;

--- a/tests/Support/TestBootstrap.php
+++ b/tests/Support/TestBootstrap.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Support;
+namespace Teufelaudio\SprykerDebug\Tests\Support;
 
 use Psr\Container\ContainerInterface;
 

--- a/tests/Support/Workspace/Workspace.php
+++ b/tests/Support/Workspace/Workspace.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Support\Workspace;
+namespace Teufelaudio\SprykerDebug\Tests\Support\Workspace;
 
 use RuntimeException;
 use Symfony\Component\Filesystem\Filesystem;

--- a/tests/TestContainer.php
+++ b/tests/TestContainer.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests;
+namespace Teufelaudio\SprykerDebug\Tests;
 
 use GuzzleHttp\Client;
-use Inviqa\SprykerDebug\Tests\Support\ApplicationBuilder;
-use Inviqa\SprykerDebug\Tests\Support\Workspace\Workspace;
+use Teufelaudio\SprykerDebug\Tests\Support\ApplicationBuilder;
+use Teufelaudio\SprykerDebug\Tests\Support\Workspace\Workspace;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use Psr\Container\ContainerInterface;
 use Pyz\Zed\Application\Communication\ApplicationCommunicationFactory;

--- a/tests/Unit/Zed/SprykerDebug/Communication/Model/Propel/CriteriaParserTest.php
+++ b/tests/Unit/Zed/SprykerDebug/Communication/Model/Propel/CriteriaParserTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Unit\Zed\SprykerDebug\Communication\Model\Propel;
+namespace Teufelaudio\SprykerDebug\Tests\Unit\Zed\SprykerDebug\Communication\Model\Propel;
 
-use Inviqa\Zed\SprykerDebug\Communication\Model\Propel\CriteriaParser;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel\CriteriaParser;
 use PHPUnit\Framework\TestCase;
 
 class CriteriaParserTest extends TestCase

--- a/tests/Unit/Zed/SprykerDebug/Communication/Model/Propel/FieldParserTest.php
+++ b/tests/Unit/Zed/SprykerDebug/Communication/Model/Propel/FieldParserTest.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Unit\Zed\SprykerDebug\Communication\Model\Propel;
+namespace Teufelaudio\SprykerDebug\Tests\Unit\Zed\SprykerDebug\Communication\Model\Propel;
 
-use Inviqa\Zed\SprykerDebug\Communication\Model\Propel\FieldParser;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Propel\FieldParser;
 use PHPUnit\Framework\TestCase;
 
 class FieldParserTest extends TestCase

--- a/tests/Unit/Zed/SprykerDebug/Communication/Model/Rabbit/QueuesTest.php
+++ b/tests/Unit/Zed/SprykerDebug/Communication/Model/Rabbit/QueuesTest.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace Inviqa\SprykerDebug\Tests\Unit\Zed\SprykerDebug\Communication\Model\Rabbit;
+namespace Teufelaudio\SprykerDebug\Tests\Unit\Zed\SprykerDebug\Communication\Model\Rabbit;
 
-use Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit\Queue;
-use Inviqa\Zed\SprykerDebug\Communication\Model\Rabbit\Queues;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Rabbit\Queue;
+use Teufelaudio\Zed\SprykerDebug\Communication\Model\Rabbit\Queues;
 use PHPUnit\Framework\TestCase;
 
 class QueuesTest extends TestCase


### PR DESCRIPTION
## Goals

The main objective of this PR is to make this fork public, so Spryker projects using PHP8.x and later versions of Spryker can work with the module.

We will need to push it to packagist, so we need to update the vendor name and in turn the PHP namespace.

I also made some further changes to fit with the latest changes from Symfony and Spryker.

## Changes

- Change vendor name and namespace
- Remove support for PHP7.4 and PHP8.0, in line with latest Spryker requirements
- Pin psr/log package to prevent conflicts with Symfony debug
- Prevent `CacheContext` from deleting the database config (no idea how this worked previously...)

